### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received a valid token")
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Potential fix for [https://github.com/saurang1984/ghas-bootcamp-demo/security/code-scanning/2](https://github.com/saurang1984/ghas-bootcamp-demo/security/code-scanning/2)

To fix the problem, we should avoid logging the sensitive authorization header directly. Instead, we can log a generic message indicating that a valid token was received without including the token itself. This approach maintains the functionality of logging important events without exposing sensitive information.

- Remove the logging of the `authz` variable on line 663.
- Replace it with a generic log message indicating that a valid token was received.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
